### PR TITLE
Fix "Failed to execute 'appendBuffer'" exception

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -58,6 +58,9 @@ export default class VideoConverter {
                     }
                     debug.log(`  video.currentTime=${this.element.currentTime}`);
                     debug.log(`  video.readyState=${this.element.readyState}`);
+                    if (this.sourceBuffer.updating) {
+                        return;
+                    }
                     const data = this.queue.shift();
                     if (data) {
                         this.doAppend(data);


### PR DESCRIPTION
Chrome throws `DOMException` (`Failed to execute 'appendBuffer' on 'SourceBuffer': This SourceBuffer is still processing an 'appendBuffer' or 'remove' operation.`) when we try to call `appendBuffer` while `sourceBuffer.updating` is `true`.

Somehow it can be `true` even when we are in the `updateend` handler.