### PR TITLE
Export sourceBuffer. Create initSegment's

### DIFF
--- a/src/h264-parser.ts
+++ b/src/h264-parser.ts
@@ -75,22 +75,18 @@ export default class H264Parser {
                 push = this.parseSEI(unit.getData().subarray(4));
                 break;
             case NALU.SPS:
-                if (this.track.sps.length === 0) {
-                    // debug.log(`  SPS: length=${unit.getData().byteLength}, ${unit.getData().subarray(4).byteLength}`);
-                    this.parseSPS(unit.getData().subarray(4));
-                    debug.log(` Found SPS type NALU frame.`);
-                    if (!this.remuxer.readyToDecode && this.track.pps.length > 0 && this.track.sps.length > 0) {
-                        this.remuxer.readyToDecode = true;
-                    }
+                // debug.log(`  SPS: length=${unit.getData().byteLength}, ${unit.getData().subarray(4).byteLength}`);
+                this.parseSPS(unit.getData().subarray(4));
+                debug.log(` Found SPS type NALU frame.`);
+                if (!this.remuxer.readyToDecode && this.track.pps.length > 0 && this.track.sps.length > 0) {
+                    this.remuxer.readyToDecode = true;
                 }
                 break;
             case NALU.PPS:
-                if (this.track.pps.length === 0) {
-                    this.parsePPS(unit.getData().subarray(4));
-                    debug.log(` Found PPS type NALU frame.`);
-                    if (!this.remuxer.readyToDecode && this.track.pps.length > 0 && this.track.sps.length > 0) {
-                        this.remuxer.readyToDecode = true;
-                    }
+                this.parsePPS(unit.getData().subarray(4));
+                debug.log(` Found PPS type NALU frame.`);
+                if (!this.remuxer.readyToDecode && this.track.pps.length > 0 && this.track.sps.length > 0) {
+                    this.remuxer.readyToDecode = true;
                 }
                 break;
             default:

--- a/src/h264-remuxer.ts
+++ b/src/h264-remuxer.ts
@@ -63,6 +63,7 @@ export default class H264Remuxer {
         if (this.parser.parseNAL(nalu)) {
             this.unitSamples[this.unitSamples.length - 1].push(nalu);
             this.mp4track.len += nalu.getSize();
+            this.mp4track.isKeyFrame = nalu.isKeyframe();
         }
         if (!this.mp4track.seiBuffering && (nalu.type() === NALU.IDR || nalu.type() === NALU.NDR)) {
             return this.createNextFrame();

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,7 +9,6 @@ export { setLogger } from './util/debug';
 export default class VideoConverter {
 
     private mediaSource: MediaSource;
-    private sourceBuffer: SourceBuffer;
     private receiveBuffer: VideoStreamBuffer = new VideoStreamBuffer();
     private remuxer: H264Remuxer;
 
@@ -17,6 +16,8 @@ export default class VideoConverter {
     private mediaReadyPromise: Promise<void> | undefined;
     private queue: Uint8Array[] = [];
     private isFirstFrame: boolean;
+
+    public sourceBuffer: SourceBuffer;
 
     static get errorNotes() {
         return {


### PR DESCRIPTION
Hi. I use this project in [ws-scrcpy](https://github.com/NetrisTV/ws-scrcpy) to display smartphone screen in a web browser.

1. For a long session it is possible to use all available memory, so I need to be able to remove data from `SourceBuffer`. 

```typescript
const converter = new VideoConverter(tag, fps, fpf);

// later, when we know we have too much data buffered
if (!converter.sourceBuffer.updating) {
    converter.sourceBuffer.remove(start, end);
}
```

2. When device is rotated, I receive `SPS` frame with new dementions. To handle changes I need:
2.1. Parse each `SPS` & `PPS`
2.2. Create `initSegment`'s for each IDR frame

Also in Safari video rendering will stop, if you remove last `initSegment`, i.e. we can't remove segments from `SourceBuffer` in Safari in the current version (because `VideoConverter` creates only one `initSegment`).

refs https://github.com/NetrisTV/ws-scrcpy/issues/111