### PR TITLE
fix: VideoConverter.reset()

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -107,8 +107,12 @@ export default class VideoConverter {
     public reset(): void {
         this.receiveBuffer.clear();
         if (this.mediaSource && this.mediaSource.readyState === 'open') {
-            this.mediaSource.duration = 0;
-            this.mediaSource.endOfStream();
+            if (this.sourceBuffer.updating) {
+                const mediaSource = this.mediaSource;
+                this.sourceBuffer.addEventListener('updateend', () => {
+                    mediaSource.endOfStream();
+                });
+            }
         }
         this.mediaSource = new MediaSource();
         this.remuxer = new H264Remuxer(this.fps, this.fpf, this.fps * 60);


### PR DESCRIPTION
- Setting MediaSource.duration can no longer truncate currently buffered media. https://www.chromestatus.com/features/6107495151960064.

- Calling "mediaSource.endOfStream()" while "sourceBuffer.updating" will cause error

fix #9